### PR TITLE
fix(setup): setup runs without errors

### DIFF
--- a/hardware/simulation/src/iob_soc_sim_wrapper.v
+++ b/hardware/simulation/src/iob_soc_sim_wrapper.v
@@ -17,7 +17,7 @@
 `endif
 
 module iob_soc_sim_wrapper (
-`include "clk_rst_s_port.vs"
+`include "clk_en_rst_s_port.vs"
    output                             trap_o,
 
 `ifdef IOB_SOC_USE_ETHERNET

--- a/hardware/simulation/src/iob_soc_tb.cpp
+++ b/hardware/simulation/src/iob_soc_tb.cpp
@@ -100,6 +100,7 @@ int main(int argc, char **argv, char **env) {
 #endif
 
   dut->clk_i = 0;
+  dut->cke_i = 1;
   dut->arst_i = 0;
 
   // Reset sequence

--- a/hardware/simulation/src/iob_soc_tb.v
+++ b/hardware/simulation/src/iob_soc_tb.v
@@ -119,6 +119,7 @@ module iob_soc_tb;
 
    iob_soc_sim_wrapper iob_soc_sim_wrapper (
       .clk_i (clk),
+      .cke_i (1'b1),
       .arst_i (arst),
       .trap_o(trap),
 

--- a/iob_soc.py
+++ b/iob_soc.py
@@ -345,11 +345,13 @@ class iob_soc(iob_module):
             ),
         ]
 
-    def _setup(self, *args, **kwargs):
+    def _setup(self, *args, is_top=True, **kwargs):
+        self.is_top_module = is_top
+        self.set_default_build_dir()
         # Pre-setup specialized IOb-SoC functions
         pre_setup_iob_soc(self)
         # Call the superclass _setup
-        super()._setup(*args, **kwargs)
+        super()._setup(*args, is_top=is_top, **kwargs)
         # Post-setup specialized IOb-SoC functions
         post_setup_iob_soc(self)
 

--- a/lib/hardware/modules/iob_tasks/iob_tasks.py
+++ b/lib/hardware/modules/iob_tasks/iob_tasks.py
@@ -1,6 +1,3 @@
-import os
-import shutil
-
 from iob_module import iob_module
 
 

--- a/lib/scripts/iob_soc_create_system.py
+++ b/lib/scripts/iob_soc_create_system.py
@@ -36,7 +36,7 @@ def create_systemv(build_dir, top, peripherals_list, internal_wires=None):
     latest_extmem_bus_size = -1
     peripherals_with_trap = []  # List of peripherals with trap output
 
-    out_dir = os.path.join(build_dir, f"hardware/src/")
+    out_dir = os.path.join(build_dir, "hardware/src")
 
     insert_header_files(out_dir, top, peripherals_list)
 

--- a/lib/scripts/iob_soc_create_wrapper_files.py
+++ b/lib/scripts/iob_soc_create_wrapper_files.py
@@ -1,12 +1,12 @@
 import os
 
 from submodule_utils import add_prefix_to_parameters_in_string
-from iob_soc_peripherals import get_pio_signals, add_prefix_to_parameters_in_string
+from iob_soc_peripherals import get_pio_signals
 
 
 # Creates the Verilog Snippet (.vs) files required by wrappers
 def create_wrapper_files(build_dir, name, ios, confs, num_extmem_connections):
-    out_dir = os.path.join(build_dir, f"hardware/simulation/src/")
+    out_dir = os.path.join(build_dir, "hardware/simulation/src/")
     pwires_str = ""
     pportmaps_str = ""
 
@@ -79,15 +79,15 @@ def create_wrapper_files(build_dir, name, ios, confs, num_extmem_connections):
     create_interconnect_instance(out_dir, name, num_extmem_connections)
     create_cyclonev_interconnect_s_portmap(out_dir, name, num_extmem_connections)
     # If CYCLONEV-GT-DK directory exists, modify_alt_ddr3_qsys
-    if os.path.exists(os.path.join(build_dir, f"hardware/fpga/quartus/CYCLONEV-GT-DK")):
+    if os.path.exists(os.path.join(build_dir, "hardware/fpga/quartus/CYCLONEV-GT-DK")):
         modify_alt_ddr3_qsys(
             os.path.join(
-                build_dir, f"hardware/fpga/quartus/CYCLONEV-GT-DK/alt_ddr3.qsys"
+                build_dir, "hardware/fpga/quartus/CYCLONEV-GT-DK/alt_ddr3.qsys"
             ),
             num_extmem_connections,
         )
     # If KU040 directory exists, create ku040_interconnect_s_portmap and ku040_rstn
-    if os.path.exists(os.path.join(build_dir, f"hardware/fpga/vivado/AES-KU040-DB-G")):
+    if os.path.exists(os.path.join(build_dir, "hardware/fpga/vivado/AES-KU040-DB-G")):
         create_ku040_interconnect_s_portmap(out_dir, name, num_extmem_connections)
         create_ku040_rstn(out_dir, name, num_extmem_connections)
 

--- a/lib/scripts/reg_gen.py
+++ b/lib/scripts/reg_gen.py
@@ -30,15 +30,15 @@ def auto_add_reg_settings(core):
                 }
             )
 
-    if core.regs:
         # Auto-add iob_ctls module, except if use_netlist
         if core.name != "iob_ctls" and not core.use_netlist:
             from iob_ctls import iob_ctls
 
+            print("\n\nDEBUG: iob_ctls.setup()\n\n")
             iob_ctls()._setup(
                 is_top=False,
                 purpose=core.purpose,
-                topdir=f"{core.build_dir}/../",
+                topdir=f"{core.build_dir}",
             )
 
 


### PR DESCRIPTION
- add ignore_snippets list for verilog_gen.replace_includes() - this allows for setting a list of verilog snippets to ignore during regular setup replacement for snippets that are generated in post_setup()
- minor fixes for python